### PR TITLE
feat(config): ship generic oidc configuration

### DIFF
--- a/config/oidc-broker.broker
+++ b/config/oidc-broker.broker
@@ -1,0 +1,5 @@
+[authd]
+name = OIDC Broker
+brand_icon = broker_icon.png
+dbus_name = com.ubuntu.authd.oidc_broker
+dbus_object = /com/ubuntu/authd/oidc_broker


### PR DESCRIPTION
This configuration should be functional for the default oidc broker. It will then be transformed when doing the snap build.

UDENG-2046