### PR TITLE
maint: Bump Go toolchain version to 1.22.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/oidc-broker
 
 go 1.22.0
 
-toolchain go1.22.1
+toolchain go1.22.2
 
 require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf


### PR DESCRIPTION
There was a vulnerability in `net/http` on 1.22.1 and we rely on this package for the OIDC broker, so we need to bump the toolchain.