### PR TITLE
maint: Bump Go toolchain to 1.22.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/oidc-broker
 
 go 1.22.0
 
-toolchain go1.22.2
+toolchain go1.22.3
 
 require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/oidc-broker/tools
 
 go 1.22.0
 
-toolchain go1.22.1
+toolchain go1.22.3
 
 require github.com/golangci/golangci-lint v1.58.0
 


### PR DESCRIPTION
There is a vulnerability in the net pkg on go 1.22.2, updating to 1.22.3 should fix it.