### PR TITLE
feat: Prevent empty local password

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -440,6 +440,10 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *sessionInfo
 		}
 
 	case "newpassword":
+		if challenge == "" {
+			return AuthRetry, `{"message": "challenge must not be empty"}`
+		}
+
 		var ok bool
 		// This mode must always come after a authentication mode, so it has to have an auth_info.
 		authInfo, ok = session.authInfo["auth_info"].(authCachedInfo)

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -258,7 +258,8 @@ func TestIsAuthenticated(t *testing.T) {
 
 		customHandlers map[string]testutils.ProviderHandler
 
-		wantSecondCall bool
+		wantSecondCall  bool
+		secondChallenge string
 
 		preexistentToken     string
 		offlineExpiration    string
@@ -312,7 +313,7 @@ func TestIsAuthenticated(t *testing.T) {
 				"/token": testutils.UnavailableHandler(),
 			},
 		},
-
+		"Error when empty challenge is provided for local password": {firstChallenge: "-", wantSecondCall: true, secondChallenge: "-"},
 		"Error when mode is newpassword and token is not set": {
 			firstMode:     "newpassword",
 			firstAuthInfo: map[string]any{"token": nil},
@@ -434,7 +435,12 @@ func TestIsAuthenticated(t *testing.T) {
 				// Give some time for the first call
 				time.Sleep(10 * time.Millisecond)
 
-				secondAuthData := `{"challenge":"` + encryptChallenge(t, "passwordpassword", key) + `"}`
+				challenge := "passwordpassword"
+				if tc.secondChallenge == "-" {
+					challenge = ""
+				}
+
+				secondAuthData := `{"challenge":"` + encryptChallenge(t, challenge, key) + `"}`
 				if tc.invalidAuthData {
 					secondAuthData = "invalid json"
 				}

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_empty_challenge_is_provided_for_local_password/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_empty_challenge_is_provided_for_local_password/first_call
@@ -1,0 +1,3 @@
+access: next
+data: ""
+err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_empty_challenge_is_provided_for_local_password/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_empty_challenge_is_provided_for_local_password/second_call
@@ -1,0 +1,3 @@
+access: retry
+data: '{"message": "challenge must not be empty"}'
+err: <nil>


### PR DESCRIPTION
Empty strings (i.e. "") still worked as local passwords for the broker users. We now prevent the user from setting an empty password as its local one.

UDENG-3119