### PR TITLE
broker: Add support for qrcode code field

### DIFF
--- a/internal/broker/testdata/TestSelectAuthenticationMode/golden/successfully_select_qrcode_with_code
+++ b/internal/broker/testdata/TestSelectAuthenticationMode/golden/successfully_select_qrcode_with_code
@@ -1,0 +1,6 @@
+button: regenerate QR code
+code: user_code
+content: https://verification_uri.com
+label: Scan the QR code or access "https://verification_uri.com" and use the provided code
+type: qrcode
+wait: "true"


### PR DESCRIPTION
Authd supports a code field now, so expose the value as it is if the UI supports it.

Related to https://github.com/ubuntu/authd/pull/387