### PR TITLE
broker: Use native JSON marshalling to handle messages and user infos

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -413,13 +413,12 @@ type isAuthenticatedResult struct {
 	Message  string          `json:"message,omitempty"`
 }
 
-var stringifyJSON = func(b []byte, err error) (string, error) { return string(b), err }
-
 func (iar *isAuthenticatedResult) toJSON() (string, error) {
 	if iar.UserInfo == nil && iar.Message == "" {
 		return "", nil
 	}
-	return stringifyJSON(json.Marshal(iar))
+	b, err := json.Marshal(iar)
+	return string(b), err
 }
 
 func (b *Broker) handleIsAuthenticated(ctx context.Context, session *sessionInfo, authData map[string]string) isAuthenticatedResult {

--- a/internal/broker/encrypt.go
+++ b/internal/broker/encrypt.go
@@ -73,7 +73,7 @@ func decrypt(ciphered, key []byte) ([]byte, error) {
 }
 
 // decodeRawChallenge extract the base64 challenge and try to decrypt it with the private key.
-func decodeRawChallenge(priv *rsa.PrivateKey, rawChallenge string) (decoded string, err error) {
+var decodeRawChallenge = func(priv *rsa.PrivateKey, rawChallenge string) (decoded string, err error) {
 	defer func() {
 		// Override the error so that we don't leak information. Also, abstract it for the user.
 		// We still log as error for the admin to get access.

--- a/internal/broker/export_test.go
+++ b/internal/broker/export_test.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"bytes"
 	"context"
+	"crypto/rsa"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -115,4 +116,18 @@ func (b *Broker) FetchUserInfo(sessionID string, cachedInfo *authCachedInfo) (st
 	var indented bytes.Buffer
 	err = json.Indent(&indented, data, "", "\t\t")
 	return indented.String(), err
+}
+
+var ErrTestChallengeDecodeError error
+
+func init() {
+	defaultDecodeRawChallenge := decodeRawChallenge
+	decodeRawChallenge = func(priv *rsa.PrivateKey, rawChallenge string) (decoded string, err error) {
+		if ErrTestChallengeDecodeError != nil {
+			err := ErrTestChallengeDecodeError
+			ErrTestChallengeDecodeError = nil
+			return "", err
+		}
+		return defaultDecodeRawChallenge(priv, rawChallenge)
+	}
 }

--- a/internal/broker/export_test.go
+++ b/internal/broker/export_test.go
@@ -116,3 +116,16 @@ func (b *Broker) FetchUserInfo(sessionID string, cachedInfo *authCachedInfo) (st
 	err = json.Indent(&indented, data, "", "\t\t")
 	return indented.String(), err
 }
+
+func init() {
+	defaultStringifyJSON := stringifyJSON
+	stringifyJSON = func(b []byte, err error) (string, error) {
+		if err != nil {
+			return defaultStringifyJSON(b, err)
+		}
+		// Indent in testing, to improve readability of golden files
+		var indented bytes.Buffer
+		err = json.Indent(&indented, b, "", "  ")
+		return defaultStringifyJSON(indented.Bytes(), err)
+	}
+}

--- a/internal/broker/export_test.go
+++ b/internal/broker/export_test.go
@@ -1,7 +1,9 @@
 package broker
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -105,5 +107,12 @@ func (b *Broker) FetchUserInfo(sessionID string, cachedInfo *authCachedInfo) (st
 		return "", err
 	}
 
-	return b.userInfoFromClaims(uInfo, groups)
+	userInfo := b.userInfoFromClaims(uInfo, groups)
+	data, err := json.Marshal(userInfo)
+	if err != nil {
+		return "", err
+	}
+	var indented bytes.Buffer
+	err = json.Indent(&indented, data, "", "\t\t")
+	return indented.String(), err
 }

--- a/internal/broker/export_test.go
+++ b/internal/broker/export_test.go
@@ -116,16 +116,3 @@ func (b *Broker) FetchUserInfo(sessionID string, cachedInfo *authCachedInfo) (st
 	err = json.Indent(&indented, data, "", "\t\t")
 	return indented.String(), err
 }
-
-func init() {
-	defaultStringifyJSON := stringifyJSON
-	stringifyJSON = func(b []byte, err error) (string, error) {
-		if err != nil {
-			return defaultStringifyJSON(b, err)
-		}
-		// Indent in testing, to improve readability of golden files
-		var indented bytes.Buffer
-		err = json.Indent(&indented, b, "", "  ")
-		return defaultStringifyJSON(indented.Bytes(), err)
-	}
-}

--- a/internal/broker/testdata/TestFetchUserInfo/golden/successfully_fetch_user_info_with_default_home_when_not_provided
+++ b/internal/broker/testdata/TestFetchUserInfo/golden/successfully_fetch_user_info_with_default_home_when_not_provided
@@ -1,8 +1,17 @@
 {
 		"name": "test-user@email.com",
 		"uuid": "saved-user-id",
-		"gecos": "saved-user",
 		"dir": "/home/test-user@email.com",
 		"shell": "/usr/bin/bash",
-		"groups": [ {"name": "remote-group", "ugid": "12345"}, {"name": "linux-local-group", "ugid": ""} ]
+		"gecos": "saved-user",
+		"groups": [
+				{
+						"name": "remote-group",
+						"ugid": "12345"
+				},
+				{
+						"name": "linux-local-group",
+						"ugid": ""
+				}
+		]
 }

--- a/internal/broker/testdata/TestFetchUserInfo/golden/successfully_fetch_user_info_with_groups
+++ b/internal/broker/testdata/TestFetchUserInfo/golden/successfully_fetch_user_info_with_groups
@@ -1,8 +1,17 @@
 {
 		"name": "test-user@email.com",
 		"uuid": "saved-user-id",
-		"gecos": "saved-user",
 		"dir": "/home/userInfoTests/test-user@email.com",
 		"shell": "/usr/bin/bash",
-		"groups": [ {"name": "remote-group", "ugid": "12345"}, {"name": "linux-local-group", "ugid": ""} ]
+		"gecos": "saved-user",
+		"groups": [
+				{
+						"name": "remote-group",
+						"ugid": "12345"
+				},
+				{
+						"name": "linux-local-group",
+						"ugid": ""
+				}
+		]
 }

--- a/internal/broker/testdata/TestFetchUserInfo/golden/successfully_fetch_user_info_without_groups
+++ b/internal/broker/testdata/TestFetchUserInfo/golden/successfully_fetch_user_info_without_groups
@@ -1,8 +1,8 @@
 {
 		"name": "test-user@email.com",
 		"uuid": "saved-user-id",
-		"gecos": "saved-user",
 		"dir": "/home/userInfoTests/test-user@email.com",
 		"shell": "/usr/bin/bash",
-		"groups": [  ]
+		"gecos": "saved-user",
+		"groups": []
 }

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_refreshes_expired_token/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_refreshes_expired_token/first_call
@@ -1,22 +1,3 @@
 access: granted
-data: |-
-    {
-      "userinfo": {
-        "name": "test-user@email.com",
-        "uuid": "test-user-id",
-        "dir": "/home/test-user@email.com",
-        "shell": "/usr/bin/bash",
-        "gecos": "test-user",
-        "groups": [
-          {
-            "name": "remote-group",
-            "ugid": "12345"
-          },
-          {
-            "name": "linux-local-group",
-            "ugid": ""
-          }
-        ]
-      }
-    }
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_refreshes_expired_token/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_refreshes_expired_token/first_call
@@ -1,11 +1,22 @@
 access: granted
 data: |-
-    {"userinfo": {
-    		"name": "test-user@email.com",
-    		"uuid": "test-user-id",
-    		"gecos": "test-user",
-    		"dir": "/home/test-user@email.com",
-    		"shell": "/usr/bin/bash",
-    		"groups": [ {"name": "remote-group", "ugid": "12345"}, {"name": "linux-local-group", "ugid": ""} ]
-    }}
+    {
+      "userinfo": {
+        "name": "test-user@email.com",
+        "uuid": "test-user-id",
+        "dir": "/home/test-user@email.com",
+        "shell": "/usr/bin/bash",
+        "gecos": "test-user",
+        "groups": [
+          {
+            "name": "remote-group",
+            "ugid": "12345"
+          },
+          {
+            "name": "linux-local-group",
+            "ugid": ""
+          }
+        ]
+      }
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_still_allowed_if_server_is_unreachable/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_still_allowed_if_server_is_unreachable/first_call
@@ -1,11 +1,22 @@
 access: granted
 data: |-
-    {"userinfo": {
-    		"name": "test-user@email.com",
-    		"uuid": "saved-user-id",
-    		"gecos": "saved-user",
-    		"dir": "/home/test-user@email.com",
-    		"shell": "/usr/bin/bash",
-    		"groups": [ {"name": "remote-group", "ugid": "12345"}, {"name": "linux-local-group", "ugid": ""} ]
-    }}
+    {
+      "userinfo": {
+        "name": "test-user@email.com",
+        "uuid": "saved-user-id",
+        "dir": "/home/test-user@email.com",
+        "shell": "/usr/bin/bash",
+        "gecos": "saved-user",
+        "groups": [
+          {
+            "name": "remote-group",
+            "ugid": "12345"
+          },
+          {
+            "name": "linux-local-group",
+            "ugid": ""
+          }
+        ]
+      }
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_still_allowed_if_server_is_unreachable/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_still_allowed_if_server_is_unreachable/first_call
@@ -1,22 +1,3 @@
 access: granted
-data: |-
-    {
-      "userinfo": {
-        "name": "test-user@email.com",
-        "uuid": "saved-user-id",
-        "dir": "/home/test-user@email.com",
-        "shell": "/usr/bin/bash",
-        "gecos": "saved-user",
-        "groups": [
-          {
-            "name": "remote-group",
-            "ugid": "12345"
-          },
-          {
-            "name": "linux-local-group",
-            "ugid": ""
-          }
-        ]
-      }
-    }
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"saved-user","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_still_allowed_if_token_is_expired_and_server_is_unreachable/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_still_allowed_if_token_is_expired_and_server_is_unreachable/first_call
@@ -1,11 +1,22 @@
 access: granted
 data: |-
-    {"userinfo": {
-    		"name": "test-user@email.com",
-    		"uuid": "saved-user-id",
-    		"gecos": "saved-user",
-    		"dir": "/home/test-user@email.com",
-    		"shell": "/usr/bin/bash",
-    		"groups": [{"name": "saved-remote-group", "gid": "12345"}, {"name": "saved-local-group", "gid": ""}]
-    }}
+    {
+      "userinfo": {
+        "name": "test-user@email.com",
+        "uuid": "saved-user-id",
+        "gecos": "saved-user",
+        "dir": "/home/test-user@email.com",
+        "shell": "/usr/bin/bash",
+        "groups": [
+          {
+            "name": "saved-remote-group",
+            "gid": "12345"
+          },
+          {
+            "name": "saved-local-group",
+            "gid": ""
+          }
+        ]
+      }
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_still_allowed_if_token_is_expired_and_server_is_unreachable/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_still_allowed_if_token_is_expired_and_server_is_unreachable/first_call
@@ -1,22 +1,3 @@
 access: granted
-data: |-
-    {
-      "userinfo": {
-        "name": "test-user@email.com",
-        "uuid": "saved-user-id",
-        "gecos": "saved-user",
-        "dir": "/home/test-user@email.com",
-        "shell": "/usr/bin/bash",
-        "groups": [
-          {
-            "name": "saved-remote-group",
-            "gid": "12345"
-          },
-          {
-            "name": "saved-local-group",
-            "gid": ""
-          }
-        ]
-      }
-    }
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","gecos":"saved-user","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","groups":[{"name":"saved-remote-group","gid":"12345"},{"name":"saved-local-group","gid":""}]}}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_qrcode_reacquires_token/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_qrcode_reacquires_token/second_call
@@ -1,22 +1,3 @@
 access: granted
-data: |-
-    {
-      "userinfo": {
-        "name": "test-user@email.com",
-        "uuid": "test-user-id",
-        "dir": "/home/test-user@email.com",
-        "shell": "/usr/bin/bash",
-        "gecos": "test-user",
-        "groups": [
-          {
-            "name": "remote-group",
-            "ugid": "12345"
-          },
-          {
-            "name": "linux-local-group",
-            "ugid": ""
-          }
-        ]
-      }
-    }
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_qrcode_reacquires_token/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_qrcode_reacquires_token/second_call
@@ -1,11 +1,22 @@
 access: granted
 data: |-
-    {"userinfo": {
-    		"name": "test-user@email.com",
-    		"uuid": "test-user-id",
-    		"gecos": "test-user",
-    		"dir": "/home/test-user@email.com",
-    		"shell": "/usr/bin/bash",
-    		"groups": [ {"name": "remote-group", "ugid": "12345"}, {"name": "linux-local-group", "ugid": ""} ]
-    }}
+    {
+      "userinfo": {
+        "name": "test-user@email.com",
+        "uuid": "test-user-id",
+        "dir": "/home/test-user@email.com",
+        "shell": "/usr/bin/bash",
+        "gecos": "test-user",
+        "groups": [
+          {
+            "name": "remote-group",
+            "ugid": "12345"
+          },
+          {
+            "name": "linux-local-group",
+            "ugid": ""
+          }
+        ]
+      }
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_can_not_cache_token/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_can_not_cache_token/second_call
@@ -1,6 +1,3 @@
 access: retry
-data: |-
-    {
-      "message": "could not update cached info: could not cache info: could not create token directory: mkdir provider_cache_path: permission denied"
-    }
+data: '{"message":"could not update cached info: could not cache info: could not create token directory: mkdir provider_cache_path: permission denied"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_can_not_cache_token/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_can_not_cache_token/second_call
@@ -1,3 +1,6 @@
 access: retry
-data: '{"message": "could not update cached info: could not cache info: could not create token directory: mkdir provider_cache_path: permission denied"}'
+data: |-
+    {
+      "message": "could not update cached info: could not cache info: could not create token directory: mkdir provider_cache_path: permission denied"
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_can_not_be_decrypted/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_can_not_be_decrypted/first_call
@@ -1,3 +1,6 @@
 access: retry
-data: '{"message": "could not decode challenge: could not decode challenge"}'
+data: |-
+    {
+      "message": "could not decode challenge: could not decode challenge"
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_can_not_be_decrypted/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_can_not_be_decrypted/first_call
@@ -1,6 +1,3 @@
 access: retry
-data: |-
-    {
-      "message": "could not decode challenge: could not decode challenge"
-    }
+data: '{"message":"could not decode challenge: could not decode challenge"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_decoding_returns_an_error/cache/provider_url/test-user@email.com.cache
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_decoding_returns_an_error/cache/provider_url/test-user@email.com.cache
@@ -1,0 +1,1 @@
+Definitely an encrypted token

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_decoding_returns_an_error/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_decoding_returns_an_error/first_call
@@ -1,0 +1,3 @@
+access: retry
+data: '{"message":"could not decode challenge: key decoding failure message"}'
+err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_decoding_returns_an_error_with_invalid_json/cache/provider_url/test-user@email.com.cache
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_decoding_returns_an_error_with_invalid_json/cache/provider_url/test-user@email.com.cache
@@ -1,0 +1,1 @@
+Definitely an encrypted token

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_decoding_returns_an_error_with_invalid_json/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_decoding_returns_an_error_with_invalid_json/first_call
@@ -1,0 +1,3 @@
+access: retry
+data: '{"message":"could not decode challenge: \"this\" needs to be\\encoded"}'
+err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_empty_challenge_is_provided_for_local_password/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_empty_challenge_is_provided_for_local_password/second_call
@@ -1,3 +1,6 @@
 access: retry
-data: '{"message": "challenge must not be empty"}'
+data: |-
+    {
+      "message": "challenge must not be empty"
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_empty_challenge_is_provided_for_local_password/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_empty_challenge_is_provided_for_local_password/second_call
@@ -1,6 +1,3 @@
 access: retry
-data: |-
-    {
-      "message": "challenge must not be empty"
-    }
+data: '{"message":"challenge must not be empty"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_can_not_fetch_user_info/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_can_not_fetch_user_info/first_call
@@ -1,6 +1,3 @@
 access: denied
-data: |-
-    {
-      "message": "could not get required information"
-    }
+data: '{"message":"could not get required information"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_can_not_fetch_user_info/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_can_not_fetch_user_info/first_call
@@ -1,3 +1,6 @@
 access: denied
-data: '{"message": "could not get required information"}'
+data: |-
+    {
+      "message": "could not get required information"
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_id_token_is_not_set/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_id_token_is_not_set/first_call
@@ -1,6 +1,3 @@
 access: denied
-data: |-
-    {
-      "message": "could not get required information"
-    }
+data: '{"message":"could not get required information"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_id_token_is_not_set/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_id_token_is_not_set/first_call
@@ -1,3 +1,6 @@
 access: denied
-data: '{"message": "could not get required information"}'
+data: |-
+    {
+      "message": "could not get required information"
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_token_is_not_set/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_token_is_not_set/first_call
@@ -1,6 +1,3 @@
 access: denied
-data: |-
-    {
-      "message": "could not get required information"
-    }
+data: '{"message":"could not get required information"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_token_is_not_set/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_token_is_not_set/first_call
@@ -1,3 +1,6 @@
 access: denied
-data: '{"message": "could not get required information"}'
+data: |-
+    {
+      "message": "could not get required information"
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_cached_token_can't_be_refreshed/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_cached_token_can't_be_refreshed/first_call
@@ -1,6 +1,3 @@
 access: retry
-data: |-
-    {
-      "message": "could not authenticate user: could not load cached info: could not refresh token: oauth2: token expired and refresh token is not set"
-    }
+data: '{"message":"could not authenticate user: could not load cached info: could not refresh token: oauth2: token expired and refresh token is not set"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_cached_token_can't_be_refreshed/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_cached_token_can't_be_refreshed/first_call
@@ -1,3 +1,6 @@
 access: retry
-data: '{"message": "could not authenticate user: could not load cached info: could not refresh token: oauth2: token expired and refresh token is not set"}'
+data: |-
+    {
+      "message": "could not authenticate user: could not load cached info: could not refresh token: oauth2: token expired and refresh token is not set"
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_can_not_fetch_user_info/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_can_not_fetch_user_info/first_call
@@ -1,6 +1,3 @@
 access: denied
-data: |-
-    {
-      "message": "could not get user info: could not fetch user info: could not verify token: oidc: failed to unmarshal claims: invalid character '\\u008a' looking for beginning of value"
-    }
+data: '{"message":"could not get user info: could not fetch user info: could not verify token: oidc: failed to unmarshal claims: invalid character ''\\u008a'' looking for beginning of value"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_can_not_fetch_user_info/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_can_not_fetch_user_info/first_call
@@ -1,3 +1,6 @@
 access: denied
-data: '{"message": "could not get user info: could not fetch user info: could not verify token: oidc: failed to unmarshal claims: invalid character ''\u008a'' looking for beginning of value"}'
+data: |-
+    {
+      "message": "could not get user info: could not fetch user info: could not verify token: oidc: failed to unmarshal claims: invalid character '\\u008a' looking for beginning of value"
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_does_not_exist/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_does_not_exist/first_call
@@ -1,6 +1,3 @@
 access: retry
-data: |-
-    {
-      "message": "could not authenticate user: could not load cached info: could not read token: open provider_cache_path/test-user@email.com.cache: no such file or directory"
-    }
+data: '{"message":"could not authenticate user: could not load cached info: could not read token: open provider_cache_path/test-user@email.com.cache: no such file or directory"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_does_not_exist/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_does_not_exist/first_call
@@ -1,3 +1,6 @@
 access: retry
-data: '{"message": "could not authenticate user: could not load cached info: could not read token: open provider_cache_path/test-user@email.com.cache: no such file or directory"}'
+data: |-
+    {
+      "message": "could not authenticate user: could not load cached info: could not read token: open provider_cache_path/test-user@email.com.cache: no such file or directory"
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_is_invalid/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_is_invalid/first_call
@@ -1,6 +1,3 @@
 access: retry
-data: |-
-    {
-      "message": "could not authenticate user: could not load cached info: could not unmarshal token: invalid character 'T' looking for beginning of value"
-    }
+data: '{"message":"could not authenticate user: could not load cached info: could not unmarshal token: invalid character ''T'' looking for beginning of value"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_is_invalid/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_is_invalid/first_call
@@ -1,3 +1,6 @@
 access: retry
-data: '{"message": "could not authenticate user: could not load cached info: could not unmarshal token: invalid character ''T'' looking for beginning of value"}'
+data: |-
+    {
+      "message": "could not authenticate user: could not load cached info: could not unmarshal token: invalid character 'T' looking for beginning of value"
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_but_server_returns_error/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_but_server_returns_error/first_call
@@ -1,6 +1,3 @@
 access: retry
-data: |-
-    {
-      "message": "could not authenticate user: could not load cached info: could not refresh token: oauth2: cannot fetch token: 400 Bad Request\nResponse: "
-    }
+data: '{"message":"could not authenticate user: could not load cached info: could not refresh token: oauth2: cannot fetch token: 400 Bad Request\nResponse: "}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_but_server_returns_error/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_but_server_returns_error/first_call
@@ -1,5 +1,6 @@
 access: retry
 data: |-
-    {"message": "could not authenticate user: could not load cached info: could not refresh token: oauth2: cannot fetch token: 400 Bad Request
-    Response: "}
+    {
+      "message": "could not authenticate user: could not load cached info: could not refresh token: oauth2: cannot fetch token: 400 Bad Request\nResponse: "
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_can_not_get_token/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_can_not_get_token/first_call
@@ -1,6 +1,3 @@
 access: retry
-data: |-
-    {
-      "message": "could not authenticate user: oauth2: cannot fetch token: 503 Service Unavailable\nResponse: "
-    }
+data: '{"message":"could not authenticate user: oauth2: cannot fetch token: 503 Service Unavailable\nResponse: "}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_can_not_get_token/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_can_not_get_token/first_call
@@ -1,5 +1,6 @@
 access: retry
 data: |-
-    {"message": "could not authenticate user: oauth2: cannot fetch token: 503 Service Unavailable
-    Response: "}
+    {
+      "message": "could not authenticate user: oauth2: cannot fetch token: 503 Service Unavailable\nResponse: "
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_response_is_invalid/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_response_is_invalid/first_call
@@ -1,3 +1,6 @@
 access: denied
-data: '{"message": "could not get required response"}'
+data: |-
+    {
+      "message": "could not get required response"
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_response_is_invalid/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_response_is_invalid/first_call
@@ -1,6 +1,3 @@
 access: denied
-data: |-
-    {
-      "message": "could not get required response"
-    }
+data: '{"message":"could not get required response"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_provided_wrong_challenge/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_provided_wrong_challenge/first_call
@@ -1,3 +1,6 @@
 access: retry
-data: '{"message": "could not authenticate user: could not load cached info: could not deserialize token: cipher: message authentication failed"}'
+data: |-
+    {
+      "message": "could not authenticate user: could not load cached info: could not deserialize token: cipher: message authentication failed"
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_provided_wrong_challenge/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_provided_wrong_challenge/first_call
@@ -1,6 +1,3 @@
 access: retry
-data: |-
-    {
-      "message": "could not authenticate user: could not load cached info: could not deserialize token: cipher: message authentication failed"
-    }
+data: '{"message":"could not authenticate user: could not load cached info: could not deserialize token: cipher: message authentication failed"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_password/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_password/first_call
@@ -1,11 +1,22 @@
 access: granted
 data: |-
-    {"userinfo": {
-    		"name": "test-user@email.com",
-    		"uuid": "saved-user-id",
-    		"gecos": "saved-user",
-    		"dir": "/home/test-user@email.com",
-    		"shell": "/usr/bin/bash",
-    		"groups": [ {"name": "remote-group", "ugid": "12345"}, {"name": "linux-local-group", "ugid": ""} ]
-    }}
+    {
+      "userinfo": {
+        "name": "test-user@email.com",
+        "uuid": "saved-user-id",
+        "dir": "/home/test-user@email.com",
+        "shell": "/usr/bin/bash",
+        "gecos": "saved-user",
+        "groups": [
+          {
+            "name": "remote-group",
+            "ugid": "12345"
+          },
+          {
+            "name": "linux-local-group",
+            "ugid": ""
+          }
+        ]
+      }
+    }
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_password/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_password/first_call
@@ -1,22 +1,3 @@
 access: granted
-data: |-
-    {
-      "userinfo": {
-        "name": "test-user@email.com",
-        "uuid": "saved-user-id",
-        "dir": "/home/test-user@email.com",
-        "shell": "/usr/bin/bash",
-        "gecos": "saved-user",
-        "groups": [
-          {
-            "name": "remote-group",
-            "ugid": "12345"
-          },
-          {
-            "name": "linux-local-group",
-            "ugid": ""
-          }
-        ]
-      }
-    }
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"saved-user","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_qrcode+newpassword/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_qrcode+newpassword/second_call
@@ -1,22 +1,3 @@
 access: granted
-data: |-
-    {
-      "userinfo": {
-        "name": "test-user@email.com",
-        "uuid": "test-user-id",
-        "dir": "/home/test-user@email.com",
-        "shell": "/usr/bin/bash",
-        "gecos": "test-user",
-        "groups": [
-          {
-            "name": "remote-group",
-            "ugid": "12345"
-          },
-          {
-            "name": "linux-local-group",
-            "ugid": ""
-          }
-        ]
-      }
-    }
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_qrcode+newpassword/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_qrcode+newpassword/second_call
@@ -1,11 +1,22 @@
 access: granted
 data: |-
-    {"userinfo": {
-    		"name": "test-user@email.com",
-    		"uuid": "test-user-id",
-    		"gecos": "test-user",
-    		"dir": "/home/test-user@email.com",
-    		"shell": "/usr/bin/bash",
-    		"groups": [ {"name": "remote-group", "ugid": "12345"}, {"name": "linux-local-group", "ugid": ""} ]
-    }}
+    {
+      "userinfo": {
+        "name": "test-user@email.com",
+        "uuid": "test-user-id",
+        "dir": "/home/test-user@email.com",
+        "shell": "/usr/bin/bash",
+        "gecos": "test-user",
+        "groups": [
+          {
+            "name": "remote-group",
+            "ugid": "12345"
+          },
+          {
+            "name": "linux-local-group",
+            "ugid": ""
+          }
+        ]
+      }
+    }
 err: <nil>

--- a/internal/providers/group/info.go
+++ b/internal/providers/group/info.go
@@ -3,6 +3,6 @@ package group
 
 // Info represents the group information that is fetched by the broker.
 type Info struct {
-	Name string
-	UGID string
+	Name string `json:"name"`
+	UGID string `json:"ugid"`
 }


### PR DESCRIPTION
During the test phase we got errors messages whose encoding wasn't correct JSON, causing unexpected errors.

To prevent this, just use native go JSON encoding to prevent us to have to manage special cases that may break the assumptions, and be always safer.

UDENG-3428