### PR TITLE
fix(broker): Improve newpassword label for passwd sessions

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -333,9 +333,14 @@ func (b *Broker) generateUILayout(session *sessionInfo, authModeID string) (map[
 		}
 
 	case "newpassword":
+		label := "Create a local password"
+		if session.mode == "passwd" {
+			label = "Update your local password"
+		}
+
 		uiLayout = map[string]string{
 			"type":  "newpassword",
-			"label": "Create a local password",
+			"label": label,
 			"entry": "chars_password",
 		}
 	}

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -218,6 +218,7 @@ func TestSelectAuthenticationMode(t *testing.T) {
 
 		tokenExists    bool
 		secondAuthStep bool
+		passwdSession  bool
 		customHandlers map[string]testutils.ProviderHandler
 
 		wantErr bool
@@ -225,6 +226,8 @@ func TestSelectAuthenticationMode(t *testing.T) {
 		"Successfully select password":    {modeName: "password", tokenExists: true},
 		"Successfully select device_auth": {modeName: "device_auth"},
 		"Successfully select newpassword": {modeName: "newpassword", secondAuthStep: true},
+
+		"Selected newpassword shows correct label in passwd session": {modeName: "newpassword", passwdSession: true, tokenExists: true, secondAuthStep: true},
 
 		"Error when selecting invalid mode": {modeName: "invalid", wantErr: true},
 		"Error when selecting device_auth but provider is unavailable": {modeName: "device_auth", wantErr: true,
@@ -248,7 +251,12 @@ func TestSelectAuthenticationMode(t *testing.T) {
 				provider = p
 			}
 
-			b, sessionID, _ := newBrokerForTests(t, t.TempDir(), provider.URL, "auth")
+			sessionType := "auth"
+			if tc.passwdSession {
+				sessionType = "passwd"
+			}
+
+			b, sessionID, _ := newBrokerForTests(t, t.TempDir(), provider.URL, sessionType)
 			if tc.tokenExists {
 				err := os.MkdirAll(filepath.Dir(b.TokenPathForSession(sessionID)), 0700)
 				require.NoError(t, err, "Setup: MkdirAll should not have returned an error")

--- a/internal/broker/testdata/TestSelectAuthenticationMode/golden/selected_newpassword_shows_correct_label_in_passwd_session
+++ b/internal/broker/testdata/TestSelectAuthenticationMode/golden/selected_newpassword_shows_correct_label_in_passwd_session
@@ -1,0 +1,3 @@
+entry: chars_password
+label: Update your local password
+type: newpassword


### PR DESCRIPTION
We used to show the same label for both sessions types (auth and passwd), but this could create confusion for users when, in passwd sessions, they were asked to "Create local password" instead of changing it. This commit should make things clearer and easier to navigate.

UDENG-3423